### PR TITLE
Allow for work on different deployment models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ The OHTTP working group will include an applicability statement that documents
 the limitations of this design and any usage constraints that are necessary to
 ensure that the protocol is secure.
 
-The working group will define a format for any encryption keys that are needed.
-The working group will not describe how encryption keys are obtained.  The
-working group will not define any methods for discovering proxy or server
-endpoints; specific uses of the protocol will need to describe discovery methods
-or rely on configuration.
+The working group will prioritize work on the core protocol elements as
+identified.  Specific uses of this core protocol might need to describe
+discovery methods or rely on configuration.  The working group may discuss and
+document different deployment models.  The working group may publish protocol
+mechanisms that support selected deployment models.
 
 The OHTTP working group will work closely with other groups that develop the
 tools that OHTTP depends on (HTTPbis for HTTP, CFRG for HPKE) or that might use

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ the limitations of this design and any usage constraints that are necessary to
 ensure that the protocol is secure.
 
 The working group will prioritize work on the core protocol elements as
-identified.  Specific uses of this core protocol might need to describe
-discovery methods or rely on configuration.  The working group may discuss and
-document different deployment models.  The working group may publish protocol
-mechanisms that support selected deployment models.
+identified.  In addition, the working group may work on other use cases and
+deployment models, including those that involve discovery of OHTTP proxies or
+servers.
 
 The OHTTP working group will work closely with other groups that develop the
 tools that OHTTP depends on (HTTPbis for HTTP, CFRG for HPKE) or that might use


### PR DESCRIPTION
As noted on the list, ruling discovery completely out of bounds wasn't
the greatest thing ever for DoH.

The intent here is to explicitly keep discussion of implications in
scope, but to avoid having it overwhelm the core work by clearly
indicating that the core protocol elements take priority.

Allowing the group to discuss deployment models and document them should
help.  This extends to allowing the working group to work on mechanisms
in support of those deployment models.  If the group decides that there
is a viable mechanism that depends on some sort of discovery mechanism,
then the definition of the necessary mechanisms can be done under the
charter.

The usual negotiation with Area Directors about the addition of new
milestones remain in full force, so this isn't an unbounded scope.  In
particular, the initial charter won't include explicit milestones for
specific work in this area.