### PR TITLE
More editorial work

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ need to be correlated, the Oblivious HTTP protocol allows a supporting server to
 accept requests via a proxy.  The proxy ensures that the server cannot see
 source addressing information for clients, which prevents servers linking
 requests to the same client using such information.  Encryption ensures that the
-proxy is unable to read requests or responses.
+proxy is unable to read requests or responses.  However, if the proxy and server
+collude, then neither of these privacy properties hold.
 
-Example applications and use cases fit for the Oblivious HTTP protocol include
-DNS, data or telemetry submission, and certificate revocation checking. In some
-of these application deployments, the relationship between client, server, and
-cooperating proxy is typically configured out-of-band.
+Applications and use cases best suited for the Oblivious HTTP protocol are those
+that have discrete queries that might reveal small amounts of information over
+time.  Examples include DNS queries, data or telemetry submission, and
+certificate revocation checking. In some of these application deployments, the
+relationship between client, server, and cooperating proxy is typically
+configured out-of-band.
 
 General purpose HTTP applications such as web browsing are not in scope for the
 Oblivious HTTP protocol. Broad applicability is limited by multiple factors,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ proxy is unable to read requests or responses.  However, if the proxy and server
 collude, then neither of these privacy properties hold.
 
 Applications and use cases best suited for the Oblivious HTTP protocol are those
-that have discrete queries that might reveal small amounts of information over
+that have discrete, transactional queries that might reveal small amounts of information over
 time.  Examples include DNS queries, data or telemetry submission, and
 certificate revocation checking. In some of these application deployments, the
 relationship between client, server, and cooperating proxy is typically

--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ Even without client identity, a server might be able to build a profile of
 client activity by correlating requests from the same client over time.
 
 In HTTP-based applications where the information included in requests does not
-need to be correlated, the Oblivious HTTP protocol allows a supporting server to accept
-requests via a proxy.  The proxy ensures that the server cannot see source addressing
-information for clients, which prevents servers linking requests to the same
-client using such information.  Encryption ensures that the proxy is unable to read
-requests or responses.
+need to be correlated, the Oblivious HTTP protocol allows a supporting server to
+accept requests via a proxy.  The proxy ensures that the server cannot see
+source addressing information for clients, which prevents servers linking
+requests to the same client using such information.  Encryption ensures that the
+proxy is unable to read requests or responses.
 
-Example applications and use cases fit for the Oblivious HTTP protocol include DNS,
-data or telemetry submission, and certificate revocation checking. In some of these
-application deployments, the relationship between client, server, and cooperating
-proxy is typically configured out-of-band.
+Example applications and use cases fit for the Oblivious HTTP protocol include
+DNS, data or telemetry submission, and certificate revocation checking. In some
+of these application deployments, the relationship between client, server, and
+cooperating proxy is typically configured out-of-band.
 
 General purpose HTTP applications such as web browsing are not in scope for the
-Oblivious HTTP protocol. Broad applicability is limited by multiple factors, including
-the need for explicit server support of the protocol. In contrast, transport-level
-proxies such as HTTP CONNECT or MASQUE are a more appropriate mechanism for those use
-cases, as they allow connecting to unmodified servers.
+Oblivious HTTP protocol. Broad applicability is limited by multiple factors,
+including the need for explicit server support of the protocol. In contrast,
+transport-level proxies such as HTTP CONNECT or MASQUE are a more appropriate
+mechanism for those use cases, as they allow connecting to unmodified servers.
 
 The OHTTP working group will define the Oblivious HTTP protocol, a method of
 encapsulating HTTP requests and responses that provides protected, low-latency


### PR DESCRIPTION
This reworks @ekr's contribution in #5 (the text already said the first
part of his addition).

This also rewords the language on examples a little.  I agree with Chris
that the main thrust of the anti-general purpose thing is server
support.  Turns out, you could use this for general purpose browsing,
including using cookies, if you cared less about linking requests.  That
would hide IP addresses, which is not a negligible thing.  Performance
is worse, certainly, but that is still stymied by the lack of server
support.

Eric O is ALSO right: a two-layer proxy system could use this as an
anonymization system, but the anti-abuse systems would need a lot of
work.